### PR TITLE
Use builder.adapter instead of builder.use

### DIFF
--- a/lib/link_preview/http_client.rb
+++ b/lib/link_preview/http_client.rb
@@ -89,7 +89,7 @@ module LinkPreview
         builder.use ForceUTF8Body
         @config.middleware.each { |middleware| builder.use middleware }
 
-        builder.use @config.http_adapter
+        builder.adapter @config.http_adapter
       end
     end
 


### PR DESCRIPTION
Before this change:
```
[35] pry(main)> LinkPreview.fetch('https://get.slaask.com?t=ibefrr', { width: 244 }).as_oembed
Adapter should be set using the `adapter` method, not `use`
=> {:version=>"1.0",
 :provider_name=>"get.slaask.com",
 :provider_url=>"https://get.slaask.com",
 :url=>"https://get.slaask.com?t=ibefrr",
 :title=>"https://get.slaask.com?t=ibefrr",
 :type=>"link"}
```

After this change:
```
[1] pry(main)> LinkPreview.fetch('https://get.slaask.com?t=ibefrr', { width: 244 }).as_oembed
=> {:version=>"1.0",
 :provider_name=>"Slaask",
 :provider_url=>"https://get.slaask.com",
 :url=>"https://get.slaask.com",
 :title=>"Slaask - The customer service app for all Slack users",
 :favicon=>"https://get.slaask.com/wp-content/themes/slaask-landing/images/favicon.png",
 :description=>
  "Interact with your leads and customers wherever they are from a single point in space: Slack! Sign up for Free!",
 :type=>"link"}
```