### PR TITLE
Take only content type into account for images

### DIFF
--- a/lib/link_preview/content.rb
+++ b/lib/link_preview/content.rb
@@ -334,7 +334,7 @@ module LinkPreview
     end
 
     def content_type_image?
-      (image_content_type =~ /image/ || image_content_type == 'binary/octet-stream' || image_content_type == 'image/svg+xml') && (get_property(:type) == 'image' || get_property(:title) == url)
+      (image_content_type =~ /image/ || image_content_type == 'binary/octet-stream' || image_content_type == 'image/svg+xml')
     end
 
     def content_html

--- a/lib/link_preview/version.rb
+++ b/lib/link_preview/version.rb
@@ -19,5 +19,5 @@
 # SOFTWARE.
 
 module LinkPreview
-  VERSION = '0.3.14'.freeze
+  VERSION = '0.3.15'.freeze
 end


### PR DESCRIPTION
J'ai des soucis avec uploadcare, j'ai ça dans la condition : 
```
      puts image_content_type
      puts get_property(:type)
      puts get_property(:title)
      puts url
```
```
image/jpeg

https://ucarecdn.com/aa110a72-386e-4d4c-b507-57d994e45ffb
https://ucarecdn.com/aa110a72-386e-4d4c-b507-57d994e45ffb/
```
Ça casse la condition
`(get_property(:type) == 'image' || get_property(:title) == url)`