### PR TITLE
Take the header content type to detect images

### DIFF
--- a/lib/link_preview/content.rb
+++ b/lib/link_preview/content.rb
@@ -40,10 +40,11 @@ module LinkPreview
       :content_url,
       :content_type,
       :content_width,
-      :content_height
+      :content_height,
+      :page_content_type
     ].freeze
 
-    SOURCES = [:initial, :image, :oembed, :opengraph_embed, :opengraph, :html].freeze
+    SOURCES = [:headers, :initial, :image, :oembed, :opengraph_embed, :opengraph, :html].freeze
 
     SOURCE_PROPERTIES_TABLE =
       {
@@ -245,6 +246,8 @@ module LinkPreview
         [:html, :oembed, :opengraph_oembed, :opengraph, :default]
       when :image_data, :image_content_type, :image_file_name
         [:image, :oembed, :opengraph_oembed, :opengraph, :default]
+      when :page_content_type
+        [:headers]
       else
         [:oembed, :opengraph_oembed, :opengraph, :html, :image, :default]
       end
@@ -334,7 +337,7 @@ module LinkPreview
     end
 
     def content_type_image?
-      (image_content_type =~ /image/ || image_content_type == 'binary/octet-stream' || image_content_type == 'image/svg+xml')
+      page_content_type =~ /image/ || page_content_type == 'binary/octet-stream' || page_content_type == 'image/svg+xml'
     end
 
     def content_html

--- a/lib/link_preview/content.rb
+++ b/lib/link_preview/content.rb
@@ -337,7 +337,9 @@ module LinkPreview
     end
 
     def content_type_image?
-      page_content_type =~ /image/ || page_content_type == 'binary/octet-stream' || page_content_type == 'image/svg+xml'
+      page_is_image = page_content_type =~ /image/ || page_content_type == 'binary/octet-stream'
+      page_is_image_viewer = (image_content_type =~ /image/ || image_content_type == 'binary/octet-stream') && (get_property(:type) == 'image' || get_property(:title) == url)
+      page_is_image || page_is_image_viewer
     end
 
     def content_html

--- a/lib/link_preview/parser.rb
+++ b/lib/link_preview/parser.rb
@@ -34,7 +34,7 @@ module LinkPreview
 
     def parse(data)
       return {} unless valid_data?(data)
-      case data.headers[:content_type]
+      properties = case data.headers[:content_type]
       when /image/, 'binary/octet-stream'
         parse_image(data)
       when %r{\Atext/html.*}
@@ -46,6 +46,10 @@ module LinkPreview
       else
         {}
       end
+      properties[:headers] = {
+        page_content_type: data.headers[:content_type]
+      }
+      properties
     end
 
     private

--- a/lib/link_preview/version.rb
+++ b/lib/link_preview/version.rb
@@ -19,5 +19,5 @@
 # SOFTWARE.
 
 module LinkPreview
-  VERSION = '0.3.15'.freeze
+  VERSION = '0.3.16'.freeze
 end


### PR DESCRIPTION
Je pense que c'est good les résultats ont l'air plutôt bons.

Globalement j'ai fait deux conditions :

- Est-ce que le content type de la page de base est une image ?
- Est-ce que c'est html mais que ça a l'air d'être un image viewer ?

```
urls.map { |url|
  [url, LinkPreview.fetch(url).as_oembed[:type]]
}
```
```
[["https://google.fr", "link"],
 ["https://www.youtube.com/watch?v=z2ed0Tazw0E", "video"],
 ["https://slack-files.com/T09LM99HV-F01A70RSUGP-394c81edd3", "photo"],
 ["https://videos.grafikundso.at/video/kiimhl38dplbj1xn8", "video"],
 ["https://ucarecdn.com/aa110a72-386e-4d4c-b507-57d994e45ffb/", "photo"],
 ["https://shyked.fr/", "link"],
 ["http://shyked.fr/?p=work&id=28", "link"],
 ["https://www.dropbox.com/s/n1yvyy6etxy3ub2/Zendesk%20Flow%20Builder%20Demo.mov?dl=0", "link"],
 ["https://www.dropbox.com/s/9ic0ba7o6y74pop/Screen%20Shot%202020-10-16%20at%2011.22.16.png?dl=0",
  "link"]]
```